### PR TITLE
feat(image): adding `only-if-cached` cache control option

### DIFF
--- a/packages/react-native/Libraries/Image/ImageSource.d.ts
+++ b/packages/react-native/Libraries/Image/ImageSource.d.ts
@@ -51,7 +51,7 @@ export interface ImageURISource {
    * to a URL load request, no attempt is made to load the data from the originating source,
    * and the load is considered to have failed.
    *
-   * @platform ios (for `force-cache` and `only-if-cached`)
+   * @platform ios (for `force-cache`)
    */
   cache?: 'default' | 'reload' | 'force-cache' | 'only-if-cached' | undefined;
   /**

--- a/packages/react-native/Libraries/Image/ImageSource.js
+++ b/packages/react-native/Libraries/Image/ImageSource.js
@@ -66,7 +66,7 @@ export interface ImageURISource {
    * to a URL load request, no attempt is made to load the data from the originating source,
    * and the load is considered to have failed.
    *
-   * @platform ios (for `force-cache` and `only-if-cached`)
+   * @platform ios (for `force-cache`)
    */
   +cache?: ?('default' | 'reload' | 'force-cache' | 'only-if-cached');
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ImageCacheControl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ImageCacheControl.kt
@@ -15,4 +15,11 @@ public enum class ImageCacheControl {
    * be used to satisfy a URL load request.
    */
   RELOAD,
+  /**
+   * The existing cache data will be used to satisfy a request, regardless of
+   * its age or expiration date. If there is no existing data in the cache corresponding
+   * to a URL load request, no attempt is made to load the data from the originating source,
+   * and the load is considered to have failed.
+   */
+  ONLY_IF_CACHED,
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ReactOkHttpNetworkFetcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ReactOkHttpNetworkFetcher.kt
@@ -43,6 +43,9 @@ internal class ReactOkHttpNetworkFetcher(private val okHttpClient: OkHttpClient)
         ImageCacheControl.RELOAD -> {
           cacheControlBuilder.noCache()
         }
+        ImageCacheControl.ONLY_IF_CACHED -> {
+          cacheControlBuilder.onlyIfCached()
+        }
         ImageCacheControl.DEFAULT -> {
           // No-op
         }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
@@ -456,12 +456,30 @@ public class ReactImageView(
 
           if (isInCache) {
             setupImageRequest(uri, cacheControl, postprocessor, resizeOptions)
+          } else {
+            val eventDispatcher =
+              UIManagerHelper.getEventDispatcherForReactTag(context as ReactContext, id)
+            eventDispatcher?.dispatchEvent(
+              createErrorEvent(
+                UIManagerHelper.getSurfaceId(this@ReactImageView),
+                id,
+                Exception("Image not found in cache for uri $uri")
+              )
+            )
           }
 
           dataSource.close()
         }
 
-        override fun onFailureImpl(dataSource: DataSource<Boolean>) {}
+        override fun onFailureImpl(dataSource: DataSource<Boolean>) {
+          val failureCause = dataSource.failureCause ?: Throwable("Unknown error occurred while checking if image is in cache")
+
+          val eventDispatcher =
+              UIManagerHelper.getEventDispatcherForReactTag(context as ReactContext, id)
+          eventDispatcher?.dispatchEvent(
+              createErrorEvent(
+                  UIManagerHelper.getSurfaceId(this@ReactImageView), id, failureCause))
+        }
       }, CallerThreadExecutor.getInstance())
 
       return

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
@@ -25,8 +25,8 @@ import android.net.Uri
 import com.facebook.common.executors.CallerThreadExecutor
 import com.facebook.common.references.CloseableReference
 import com.facebook.common.util.UriUtil
-import com.facebook.datasource.DataSource
 import com.facebook.datasource.BaseDataSubscriber
+import com.facebook.datasource.DataSource
 import com.facebook.datasource.DataSubscriber
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.drawee.controller.AbstractDraweeControllerBuilder
@@ -439,6 +439,13 @@ public class ReactImageView(
 
     val resizeOptions = if (doResize) resizeOptions else null
 
+    val imageRequestBuilder =
+      ImageRequestBuilder.newBuilderWithSource(uri)
+        .setPostprocessor(postprocessor)
+        .setResizeOptions(resizeOptions)
+        .setAutoRotateEnabled(true)
+        .setProgressiveRenderingEnabled(progressiveRenderingEnabled)
+
     if (cacheControl == ImageCacheControl.RELOAD) {
       val imagePipeline = Fresco.getImagePipeline()
       imagePipeline.evictFromCache(uri)
@@ -446,16 +453,20 @@ public class ReactImageView(
 
     if (cacheControl == ImageCacheControl.ONLY_IF_CACHED) {
       val imagePipeline = Fresco.getImagePipeline()
-      val dataSource = imagePipeline.isInDiskCache(uri)
+      val imageRequest = imageRequestBuilder.build()
+      val dataSource = imagePipeline.isInDiskCache(imageRequest)
+      val inBitmapCache = imagePipeline.isInBitmapMemoryCache(imageRequest)
+      val inEncodedMemoryCache = imagePipeline.isInEncodedMemoryCache(imageRequest)
 
       dataSource.subscribe(object : BaseDataSubscriber<Boolean>() {
         override fun onNewResultImpl(dataSource: DataSource<Boolean>) {
           if (!dataSource.isFinished()) return
 
-          val isInCache: Boolean = dataSource.getResult() ?: false
+          val isInDiskCache: Boolean = dataSource.getResult() ?: false
+          val isInCache: Boolean = inBitmapCache || inEncodedMemoryCache || isInDiskCache
 
           if (isInCache) {
-            setupImageRequest(uri, cacheControl, postprocessor, resizeOptions)
+            setupImageRequest(imageRequestBuilder, uri, cacheControl, postprocessor, resizeOptions)
           } else {
             val eventDispatcher =
               UIManagerHelper.getEventDispatcherForReactTag(context as ReactContext, id)
@@ -472,35 +483,32 @@ public class ReactImageView(
         }
 
         override fun onFailureImpl(dataSource: DataSource<Boolean>) {
-          val failureCause = dataSource.failureCause ?: Throwable("Unknown error occurred while checking if image is in cache")
+          val failureCause = dataSource.failureCause
+            ?: Throwable("Unknown error occurred while checking if image is in cache for uri $uri")
 
           val eventDispatcher =
-              UIManagerHelper.getEventDispatcherForReactTag(context as ReactContext, id)
+            UIManagerHelper.getEventDispatcherForReactTag(context as ReactContext, id)
           eventDispatcher?.dispatchEvent(
-              createErrorEvent(
-                  UIManagerHelper.getSurfaceId(this@ReactImageView), id, failureCause))
+            createErrorEvent(
+              UIManagerHelper.getSurfaceId(this@ReactImageView), id, failureCause
+            )
+          )
         }
       }, CallerThreadExecutor.getInstance())
 
       return
     }
 
-    setupImageRequest(uri, cacheControl, postprocessor, resizeOptions)
+    setupImageRequest(imageRequestBuilder, uri, cacheControl, postprocessor, resizeOptions)
   }
 
   private fun setupImageRequest(
+    imageRequestBuilder: ImageRequestBuilder,
     uri: Uri,
     cacheControl: ImageCacheControl,
     postprocessor: Postprocessor?,
     resizeOptions: ResizeOptions?
   ) {
-    val imageRequestBuilder =
-        ImageRequestBuilder.newBuilderWithSource(uri)
-            .setPostprocessor(postprocessor)
-            .setResizeOptions(resizeOptions)
-            .setAutoRotateEnabled(true)
-            .setProgressiveRenderingEnabled(progressiveRenderingEnabled)
-
     if (resizeMethod == ImageResizeMethod.NONE) {
       imageRequestBuilder.setDownsampleOverride(DownsampleMode.NEVER)
     }

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -659,6 +659,19 @@ function CacheControlAndroidExample(): React.Node {
             key={reload}
           />
         </View>
+        <View style={styles.leftMargin}>
+          <RNTesterText style={styles.resizeModeText}>
+            Only-if-cached
+          </RNTesterText>
+          <Image
+            source={{
+              uri: fullImage.uri + '?cacheBust=only-if-cached',
+              cache: 'only-if-cached',
+            }}
+            style={styles.base}
+            key={reload}
+          />
+        </View>
       </View>
 
       <View style={styles.horizontal}>
@@ -1091,9 +1104,10 @@ exports.examples = [
   },
   {
     title: 'Cache Policy',
-    description: ('First image will be loaded and will be cached. ' +
-      'Second image is the same but will be reloaded if re-rendered ' +
-      'as the cache policy is set to reload.': string),
+    description: `- First image will be loaded and cached.
+- Second image is the same but will be reloaded if re-rendered as the cache policy is set to reload.
+- Third image will never be loaded as the cache policy is set to only-if-cached and the image has not been loaded before.
+  `,
     render: function (): React.Node {
       return <CacheControlAndroidExample />;
     },

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -670,6 +670,7 @@ function CacheControlAndroidExample(): React.Node {
             }}
             style={styles.base}
             key={reload}
+            onError={e => console.log(e.nativeEvent.error)}
           />
         </View>
       </View>


### PR DESCRIPTION
## Summary:

Follow up from ..., as there is already basic caching control in place in Android, it can be extended to also have the `only-if-cached` option.

We check whether the image is in cache, if it is in cache then we proceed to load it. Otherwise, we do nothing.

## Changelog:

[ANDROID] [ADDED] - Image `only-if-cached` cache control option

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
