### PR TITLE
feat(image): [android] adding  cache control option

### DIFF
--- a/packages/react-native/Libraries/Image/ImageSource.d.ts
+++ b/packages/react-native/Libraries/Image/ImageSource.d.ts
@@ -50,8 +50,6 @@ export interface ImageURISource {
    * its age or expiration date. If there is no existing data in the cache corresponding
    * to a URL load request, no attempt is made to load the data from the originating source,
    * and the load is considered to have failed.
-   *
-   * @platform ios (for `force-cache`)
    */
   cache?: 'default' | 'reload' | 'force-cache' | 'only-if-cached' | undefined;
   /**

--- a/packages/react-native/Libraries/Image/ImageSource.js
+++ b/packages/react-native/Libraries/Image/ImageSource.js
@@ -65,8 +65,6 @@ export interface ImageURISource {
    * its age or expiration date. If there is no existing data in the cache corresponding
    * to a URL load request, no attempt is made to load the data from the originating source,
    * and the load is considered to have failed.
-   *
-   * @platform ios (for `force-cache`)
    */
   +cache?: ?('default' | 'reload' | 'force-cache' | 'only-if-cached');
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ImageCacheControl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ImageCacheControl.kt
@@ -18,6 +18,12 @@ public enum class ImageCacheControl {
   /**
    * The existing cache data will be used to satisfy a request, regardless of
    * its age or expiration date. If there is no existing data in the cache corresponding
+   * to a URL load request, the data is loaded from the originating source.
+   */
+  FORCE_CACHE,
+  /**
+   * The existing cache data will be used to satisfy a request, regardless of
+   * its age or expiration date. If there is no existing data in the cache corresponding
    * to a URL load request, no attempt is made to load the data from the originating source,
    * and the load is considered to have failed.
    */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ReactOkHttpNetworkFetcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ReactOkHttpNetworkFetcher.kt
@@ -43,6 +43,9 @@ internal class ReactOkHttpNetworkFetcher(private val okHttpClient: OkHttpClient)
         ImageCacheControl.RELOAD -> {
           cacheControlBuilder.noCache()
         }
+        ImageCacheControl.FORCE_CACHE -> {
+          CacheControl.FORCE_CACHE
+        }
         ImageCacheControl.ONLY_IF_CACHED -> {
           cacheControlBuilder.onlyIfCached()
         }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
@@ -312,6 +312,7 @@ public class ReactImageView(
       null,
       "default" -> ImageCacheControl.DEFAULT
       "reload" -> ImageCacheControl.RELOAD
+      "force-cache" -> ImageCacheControl.FORCE_CACHE
       "only-if-cached" -> ImageCacheControl.ONLY_IF_CACHED
       else -> ImageCacheControl.DEFAULT
     }

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -660,6 +660,18 @@ function CacheControlAndroidExample(): React.Node {
           />
         </View>
         <View style={styles.leftMargin}>
+          <RNTesterText style={styles.resizeModeText}>Force-cache</RNTesterText>
+          <Image
+            source={{
+              uri: fullImage.uri + '?cacheBust=force-cache',
+              cache: 'force-cache',
+            }}
+            style={styles.base}
+            key={reload}
+            onError={e => console.log(e.nativeEvent.error)}
+          />
+        </View>
+        <View style={styles.leftMargin}>
           <RNTesterText style={styles.resizeModeText}>
             Only-if-cached
           </RNTesterText>


### PR DESCRIPTION
## Summary:

As follow up from ... and ..., `force-cache` is the last missing option to have caching control pair up with how it currently works for iOS.

Local caching options remain the same, if there is cache available we return the cached image locally. Otherwise we proceed to the request.

For the image network request, we now use the `okhttp3.CacheControl` directive `FORCE_CACHE` if we pass the `force-cache` option from the JS side.

## Changelog:

[ANDROID] [ADDED] - Image `force-cache` caching control option

## Test Plan:

New example added to the RNTester under the cache policy examples. Then inspecting that the cache control is set correctly before sending it in the `okhttp3.Request` builder.

```kt
FLog.w("ReactNative", "fetching uri: %s, with cacheControl: %s", uri, cacheControlBuilder.build().toString())
// fetching uri: https:...png?cacheBust=force-cache, with cacheControl: no-store, max-stale=2147483647, only-if-cached
```

This case was a bit more tricky to test in terms of e2e as it would involve some caching in the server as well, I'm open to suggestions to make this more complete.